### PR TITLE
fix: autodeploy

### DIFF
--- a/.github/workflows/autodeploy_ftp.yml
+++ b/.github/workflows/autodeploy_ftp.yml
@@ -9,8 +9,9 @@ jobs:
   web-deploy:
     name: 🎉 Deploy
     runs-on: ubuntu-latest
-    - name: 📂 Upload to FTP
-      uses: SamKirkland/FTP-Deploy-Action@4.0.0
+    steps:
+    - uses: actions/checkout@v2.3.2
+    - uses: SamKirkland/FTP-Deploy-Action@4.0.0
       with:
         local-dir: ./src/
         state-name: .htautodeploystate


### PR DESCRIPTION
The checkout step was missing. Without the checkout step, the action has no access to your codebase. Therefor it can't use src/ to push the code to the FTP server.